### PR TITLE
fix: Spelling error on network info page

### DIFF
--- a/pages/network_info.mdx
+++ b/pages/network_info.mdx
@@ -1,6 +1,6 @@
 # Network Info
 
-Currently, Abstract is available as a public testnet for developers. You can use the testnet today for deplying contracts and testing out the network.
+Currently, Abstract is available as a public testnet for developers. You can use the testnet today for deploying contracts and testing out the network.
 
 - See information about the testnet [here](/network_info/testnet)
 


### PR DESCRIPTION
# Changes
- fix spelling mistake for this page
- https://igloo-cube.slack.com/archives/C071YPRPMF0/p1722018504913519
