### PR TITLE
add data indexers to tools & integrations

### DIFF
--- a/pages/tools_integrations/data_indexers.mdx
+++ b/pages/tools_integrations/data_indexers.mdx
@@ -1,0 +1,17 @@
+# Data Indexers
+
+## What is a data indexer?
+
+A blockchain data indexer is a tool or service that organizes and stores blockchain data in a way that makes it easily searchable and accessible -- typically queryable by GraphQL
+
+## GhostGraph
+
+[GhostGraph](https://GhostGraph.xyz/) makes it easy to build blazingly fast indexers (subgraphs) for smart contracts.
+
+GhostGraph is the first indexing solution that lets you write your index transformations in **Solidity**. Abstract dApps can query data with GraphQL using our hosted endpoints.
+
+To get started, you can [sign up for an account](https://app.ghostlogs.xyz/ghostgraph/sign-up) and follow [this quickstart](https://docs.ghostlogs.xyz/category/-getting-started-1) guide on how to create, deploy, and query a GhostGraph.
+
+#### Supported Networks
+
+- Abstract Testnet


### PR DESCRIPTION
## Overview 

Create data indexers section and add `GhostGraph` to the data indexer.

## Testing

`$ npm run dev` and go to `/tools_integrations/data_indexers` 

## Screenshot

![data_indexers_abstract](https://github.com/user-attachments/assets/9b638f7e-fb75-4270-b7f9-f6cdc8a487a2)

## Notes to Contributors

* Feel free to modify this PR